### PR TITLE
creator-default configs: disable opkg

### DIFF
--- a/creator-platform-all-cascoda.config
+++ b/creator-platform-all-cascoda.config
@@ -13,6 +13,7 @@ CONFIG_OPENSSL_WITH_EC=y
 CONFIG_PACKAGE_ca-certificates=y
 CONFIG_PACKAGE_libopenssl=y
 CONFIG_PACKAGE_libustream-openssl=y
+# CONFIG_PACKAGE_opkg is not set
 CONFIG_PACKAGE_opkg-smime=y
 # CONFIG_PACKAGE_usign is not set
 CONFIG_PACKAGE_zlib=y
@@ -20,7 +21,7 @@ CONFIG_PACKAGE_zlib=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40All"
-CONFIG_VERSION_NUMBER="0.9.5"
+CONFIG_VERSION_NUMBER="0.9.6"
 CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"

--- a/creator-platform-all.config
+++ b/creator-platform-all.config
@@ -13,6 +13,7 @@ CONFIG_OPENSSL_WITH_EC=y
 CONFIG_PACKAGE_ca-certificates=y
 CONFIG_PACKAGE_libopenssl=y
 CONFIG_PACKAGE_libustream-openssl=y
+# CONFIG_PACKAGE_opkg is not set
 CONFIG_PACKAGE_opkg-smime=y
 # CONFIG_PACKAGE_usign is not set
 CONFIG_PACKAGE_zlib=y
@@ -20,7 +21,7 @@ CONFIG_PACKAGE_zlib=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40All"
-CONFIG_VERSION_NUMBER="0.9.5"
+CONFIG_VERSION_NUMBER="0.9.6"
 CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"


### PR DESCRIPTION
1. opkg is not needed as opkg-smime is enabled
2. Incremented version from 0.9.5 to 0.9.6

Signed-off-by: Avinash Tahakik avinashtahakik@gmail.com
